### PR TITLE
Proposition de correction de fautes d'orthographe et de traductions

### DIFF
--- a/src/main/resources/assets/mineria/lang/fr_fr.json
+++ b/src/main/resources/assets/mineria/lang/fr_fr.json
@@ -19,8 +19,8 @@
   "block.mineria.compressed_lead_spike": "Pic en Plomb Compressé",
   "block.mineria.golden_silverfish_netherrack": "Netherrack possédant un Silverfish en Or",
   "block.mineria.xp_wall": "Déco en XP",
-  "block.mineria.water_barrel": "Barril d'Eau",
-  "block.mineria.infinite_water_barrel": "Barril d'Eau Infinie",
+  "block.mineria.water_barrel": "Baril d'Eau",
+  "block.mineria.infinite_water_barrel": "Baril d'Eau Infinie",
 
   "block.mineria.xp_block": "Bloc d'XP",
   "block.mineria.titane_extractor": "Extracteur à Titane",
@@ -121,6 +121,6 @@
   "recipe_category.mineria.extractor": "Extracteur",
 
   "tooltip.mineria.buckets": "Seaux",
-  "tooltip.mineria.water_barrel.use": "Pour utiliser le barril, il vous faut le placer et faire un clic droit avec un seau d'eau pour le remplir",
+  "tooltip.mineria.water_barrel.use": "Pour utiliser le baril, il vous faut le placer et faire un clic droit avec un seau d'eau pour le remplir",
   "tooltip.mineria.water_barrel.hold_shift": "Appuyez sur SHIFT pour plus d'infos..."
 }

--- a/src/main/resources/assets/mineria/lang/fr_fr.json
+++ b/src/main/resources/assets/mineria/lang/fr_fr.json
@@ -13,14 +13,14 @@
   "block.mineria.silver_block": "Bloc d'Argent",
   "block.mineria.compressed_lead_block": "Bloc de Plomb Compressé",
 
-  "block.mineria.blue_glowstone": "Glowstone Bleue",
+  "block.mineria.blue_glowstone": "Pierre lumineuse Bleue",
   "block.mineria.mineral_sand": "Sable Minéral",
   "block.mineria.lead_spike": "Pic en Plomb",
   "block.mineria.compressed_lead_spike": "Pic en Plomb Compressé",
   "block.mineria.golden_silverfish_netherrack": "Netherrack possédant un Silverfish en Or",
   "block.mineria.xp_wall": "Déco en XP",
-  "block.mineria.water_barrel": "Baril d'Eau",
-  "block.mineria.infinite_water_barrel": "Baril d'Eau Infini",
+  "block.mineria.water_barrel": "Barril d'Eau",
+  "block.mineria.infinite_water_barrel": "Barril d'Eau Infinie",
 
   "block.mineria.xp_block": "Bloc d'XP",
   "block.mineria.titane_extractor": "Extracteur à Titane",
@@ -121,6 +121,6 @@
   "recipe_category.mineria.extractor": "Extracteur",
 
   "tooltip.mineria.buckets": "Seaux",
-  "tooltip.mineria.water_barrel.use": "Pour utiliser le baril, il vous faut le placer et faire click droit avec un seau d'eau pour le remplir",
+  "tooltip.mineria.water_barrel.use": "Pour utiliser le barril, il vous faut le placer et faire un clic droit avec un seau d'eau pour le remplir",
   "tooltip.mineria.water_barrel.hold_shift": "Appuyez sur SHIFT pour plus d'infos..."
 }


### PR DESCRIPTION
Traduction de glowstone par pierre lumineuse, pour rester cohérent avec minecraft vanilla
click s'écrit clic
c'est l'eau qui est infinie, féminin, on met un -e
